### PR TITLE
@nsc de/basic-introduce-shortcuts

### DIFF
--- a/packages/basic/changelog.md
+++ b/packages/basic/changelog.md
@@ -2,7 +2,7 @@
 
 ## v0.1.4
 
-- Introduce shortcuts for `Context#describe()`, `Context#any()`, `Context#post()`, `Context#put()`, `Context#patch()`, `Context#delete()`, `Context#options()`, `Context#head()`, `Context#get()`
+- Introduce shortcuts for actions inside of `Context#describe()`, `Context#any()`, `Context#post()`, `Context#put()`, `Context#patch()`, `Context#delete()`, `Context#options()`, `Context#head()`, `Context#get()`
 
 ## v0.1.3
 

--- a/packages/basic/changelog.md
+++ b/packages/basic/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for @rster/basic
 
+## v0.1.4
+
+- Introduce shortcuts for `Context#describe()`, `Context#any()`, `Context#post()`, `Context#put()`, `Context#patch()`, `Context#delete()`, `Context#options()`, `Context#head()`, `Context#get()`
+
 ## v0.1.3
 
 - Introduce Context#getRoutingPath()

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rster/basic",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "RSTER is a toolset for REST Api creation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/basic/src/context.test.ts
+++ b/packages/basic/src/context.test.ts
@@ -176,6 +176,36 @@ describe("Context", () => {
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
     });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.describe("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionPath);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.describe(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionPath2);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
   });
 
   describe("any", () => {
@@ -204,6 +234,36 @@ describe("Context", () => {
       expect(
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.any("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionPath);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.any(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionPath2);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
     });
   });
 
@@ -263,6 +323,51 @@ describe("Context", () => {
       expect(
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.get("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.get(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.get((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionMethod);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
     });
 
     it("Test with wrong parameters", () => {
@@ -333,6 +438,51 @@ describe("Context", () => {
       ).not.toBeUndefined();
     });
 
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.post("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.post(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.post((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionMethod);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
     it("Test with wrong parameters", () => {
       const context = createEmptyContext();
 
@@ -396,6 +546,52 @@ describe("Context", () => {
       expect(
         (context.children[0] as ContextChildCondition).condition
       ).toBeInstanceOf(ContextConditionMethod);
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.put("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.put(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "put",
+        path: "[test]",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.put((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "put",
+      });
       expect(
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
@@ -469,6 +665,52 @@ describe("Context", () => {
       ).not.toBeUndefined();
     });
 
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.patch("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.patch(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "patch",
+        path: "[test]",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.patch((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "patch",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
     it("Test with wrong parameters", () => {
       const context = createEmptyContext();
       // @ts-ignore
@@ -536,6 +778,52 @@ describe("Context", () => {
       ).not.toBeUndefined();
     });
 
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.delete("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.delete(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "delete",
+        path: "[test]",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.delete((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "delete",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
     it("Test with wrong parameters", () => {
       const context = createEmptyContext();
       // @ts-ignore
@@ -594,6 +882,53 @@ describe("Context", () => {
       expect(
         (context.children[0] as ContextChildCondition).condition
       ).toBeInstanceOf(ContextConditionMethod);
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.head("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "head",
+        path: "test",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.head(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "head",
+        path: "[test]",
+      });
+      expect(
+        (context.children[0] as ContextChildCondition).context
+      ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.head((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+      expect(
+        (context.children[0] as ContextChildCondition).condition.info()
+      ).toEqual({
+        method: "head",
+      });
       expect(
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
@@ -664,6 +999,51 @@ describe("Context", () => {
       expect(
         (context.children[0] as ContextChildCondition).context
       ).not.toBeUndefined();
+    });
+
+    it("Should add passed actions as children with string path", () => {
+      const context = createEmptyContext();
+      context.options("test", (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children with RegExp path", () => {
+      const context = createEmptyContext();
+      context.options(/test/, (req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionAnd);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
+    });
+
+    it("Should add passed actions as children without path", () => {
+      const context = createEmptyContext();
+      context.options((req, res) => {});
+      expect(context.children).toHaveLength(1);
+      expect(context.children[0].type).toEqual("condition");
+
+      const child: ContextChildCondition = context
+        .children[0] as ContextChildCondition;
+
+      expect(child.condition).toBeInstanceOf(ContextConditionMethod);
+      expect(child.context).not.toBeUndefined();
+      expect(child.context.children).toHaveLength(1);
+      expect(child.context.children[0].type).toEqual("action");
     });
 
     it("Test with wrong parameters", () => {

--- a/packages/basic/src/context.ts
+++ b/packages/basic/src/context.ts
@@ -1104,26 +1104,85 @@ export class Context {
    * ```
    */
   options(what: RegExp, init: ContextInitializer): Context;
+
+  /**
+   * Search for requests with the method OPTIONS.
+   * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.options(async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.options(function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  options(init: ActionFunction): Context;
+
+  /**
+   * Search for requests starting with the given path and requests with the method OPTIONS.
+   * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
+   * @param what - the path that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.options("/hello", async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  options(what: string, init: ActionFunction): Context;
+
+  /**
+   * Search for requests matching the given regex and requests with the method OPTIONS.
+   * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
+   * @param what - the regex that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.options(/\/hello/, async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  options(what: RegExp, init: ActionFunction): Context;
+
   options(
-    arg0: string | RegExp | ContextInitializer,
-    arg1?: ContextInitializer
+    arg0: string | RegExp | ContextInitializer | ActionFunction,
+    arg1?: ContextInitializer | ActionFunction
   ): this {
+    // options(what: string, init)
     if (typeof arg0 === "string" && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("options").and(
           new ContextConditionPath(arg0)
         ),
-        arg1
+        toInitializer(arg1)
       );
+    // options(what: RegExp, init)
     if (arg0 instanceof RegExp && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("options").and(
           new ContextConditionPath2(arg0)
         ),
-        arg1
+        toInitializer(arg1)
       );
-    else if (typeof arg0 === "function")
-      return this.when(new ContextConditionMethod("options"), arg0);
+    // options(init)
+    if (typeof arg0 === "function")
+      return this.when(
+        new ContextConditionMethod("options"),
+        toInitializer(arg0)
+      );
     throw new Error("Invalid arguments");
   }
 
@@ -1167,22 +1226,92 @@ export class Context {
    * ```
    */
   head(what: RegExp, init: ContextInitializer): Context;
+
+  /**
+   * Search for requests with the method HEAD.
+   * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.head(async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.head(function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  head(init: ActionFunction): Context;
+
+  /**
+   * Search for requests starting with the given path and requests with the method HEAD.
+   * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
+   * @param what - the path that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.head("/hello", async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.head("/hello", function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  head(what: string, init: ActionFunction): Context;
+
+  /**
+   * Search for requests matching the given regex and requests with the method HEAD.
+   * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
+   * @param what - the regex that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.head(/\/hello/, async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.head(/\/hello/, function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  head(what: RegExp, init: ActionFunction): Context;
+
   head(
-    arg0: string | RegExp | ContextInitializer,
-    arg1?: ContextInitializer
+    arg0: string | RegExp | ContextInitializer | ActionFunction,
+    arg1?: ContextInitializer | ActionFunction
   ): this {
+    // head(what: string, init)
     if (typeof arg0 === "string" && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("head").and(new ContextConditionPath(arg0)),
-        arg1
+        toInitializer(arg1)
       );
+
+    // head(what: RegExp, init)
     if (arg0 instanceof RegExp && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("head").and(new ContextConditionPath2(arg0)),
-        arg1
+        toInitializer(arg1)
       );
-    else if (typeof arg0 === "function")
-      return this.when(new ContextConditionMethod("head"), arg0);
+
+    // head(init)
+    if (typeof arg0 === "function")
+      return this.when(new ContextConditionMethod("head"), toInitializer(arg0));
     throw new Error("Invalid arguments");
   }
 

--- a/packages/basic/src/context.ts
+++ b/packages/basic/src/context.ts
@@ -429,7 +429,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method POST.
+   * Match requests with the method POST.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -441,7 +441,7 @@ export class Context {
   post(init: ContextInitializer): this;
 
   /**
-   * Search for requests starting with the given path and requests with the method POST.
+   * Match requests starting with the given path and requests with the method POST.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -455,7 +455,7 @@ export class Context {
   post(what: string, init: ContextInitializer): this;
 
   /**
-   * Search for requests matching the given regex and requests with the method POST.
+   * Match requests matching the given regex and requests with the method POST.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -469,7 +469,7 @@ export class Context {
   post(what: RegExp, init: ContextInitializer): this;
 
   /**
-   * Search for requests with the method POST.
+   * Match requests with the method POST.
    * This is a shorthand for {@link Context.post} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -488,7 +488,7 @@ export class Context {
   post(init: ActionFunction): this;
 
   /**
-   * Search for requests starting with the given path and requests with the method POST.
+   * Match requests starting with the given path and requests with the method POST.
    * This is a shorthand for {@link Context.post} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -509,7 +509,7 @@ export class Context {
   post(what: string, init: ActionFunction): this;
 
   /**
-   * Search for requests matching the given regex and requests with the method POST.
+   * Match requests matching the given regex and requests with the method POST.
    * This is a shorthand for {@link Context.post} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -554,7 +554,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method GET.
+   * Match requests with the method GET.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -567,7 +567,7 @@ export class Context {
   get(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method GET.
+   * Match requests starting with the given path and requests with the method GET.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -581,7 +581,7 @@ export class Context {
   get(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method GET.
+   * Match requests matching the given regex and requests with the method GET.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -595,7 +595,7 @@ export class Context {
   get(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method GET.
+   * Match requests with the method GET.
    * This is a shorthand for {@link Context.get} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -615,7 +615,7 @@ export class Context {
   get(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method GET.
+   * Match requests starting with the given path and requests with the method GET.
    * This is a shorthand for {@link Context.get} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -636,7 +636,7 @@ export class Context {
   get(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method GET.
+   * Match requests matching the given regex and requests with the method GET.
    * This is a shorthand for {@link Context.get} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -678,7 +678,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method PUT.
+   * Match requests with the method PUT.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -691,7 +691,7 @@ export class Context {
   put(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method PUT.
+   * Match requests starting with the given path and requests with the method PUT.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -705,7 +705,7 @@ export class Context {
   put(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method PUT.
+   * Match requests matching the given regex and requests with the method PUT.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -719,7 +719,7 @@ export class Context {
   put(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method PUT.
+   * Match requests with the method PUT.
    * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -739,7 +739,7 @@ export class Context {
   put(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method PUT.
+   * Match requests starting with the given path and requests with the method PUT.
    * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -760,7 +760,7 @@ export class Context {
   put(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method PUT.
+   * Match requests matching the given regex and requests with the method PUT.
    * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -803,7 +803,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method PATCH.
+   * Match requests with the method PATCH.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -816,7 +816,7 @@ export class Context {
   patch(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method PATCH.
+   * Match requests starting with the given path and requests with the method PATCH.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -830,7 +830,7 @@ export class Context {
   patch(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method PATCH.
+   * Match requests matching the given regex and requests with the method PATCH.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -844,7 +844,7 @@ export class Context {
   patch(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method PATCH.
+   * Match requests with the method PATCH.
    * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -864,7 +864,7 @@ export class Context {
   patch(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method PATCH.
+   * Match requests starting with the given path and requests with the method PATCH.
    * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -885,7 +885,7 @@ export class Context {
   patch(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method PATCH.
+   * Match requests matching the given regex and requests with the method PATCH.
    * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -933,7 +933,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method DELETE.
+   * Match requests with the method DELETE.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -946,7 +946,7 @@ export class Context {
   delete(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method DELETE.
+   * Match requests starting with the given path and requests with the method DELETE.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -960,7 +960,7 @@ export class Context {
   delete(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method DELETE.
+   * Match requests matching the given regex and requests with the method DELETE.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -974,7 +974,7 @@ export class Context {
   delete(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method DELETE.
+   * Match requests with the method DELETE.
    * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -994,7 +994,7 @@ export class Context {
   delete(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method DELETE.
+   * Match requests starting with the given path and requests with the method DELETE.
    * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -1015,7 +1015,7 @@ export class Context {
   delete(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method DELETE.
+   * Match requests matching the given regex and requests with the method DELETE.
    * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -1065,7 +1065,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method OPTIONS.
+   * Match requests with the method OPTIONS.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -1078,7 +1078,7 @@ export class Context {
   options(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method OPTIONS.
+   * Match requests starting with the given path and requests with the method OPTIONS.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -1092,7 +1092,7 @@ export class Context {
   options(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method OPTIONS.
+   * Match requests matching the given regex and requests with the method OPTIONS.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -1106,7 +1106,7 @@ export class Context {
   options(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method OPTIONS.
+   * Match requests with the method OPTIONS.
    * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -1126,7 +1126,7 @@ export class Context {
   options(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method OPTIONS.
+   * Match requests starting with the given path and requests with the method OPTIONS.
    * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -1142,7 +1142,7 @@ export class Context {
   options(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method OPTIONS.
+   * Match requests matching the given regex and requests with the method OPTIONS.
    * This is a shorthand for {@link Context.options} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
@@ -1187,7 +1187,7 @@ export class Context {
   }
 
   /**
-   * Search for requests with the method HEAD.
+   * Match requests with the method HEAD.
    * @param init - the action happening when the condition is met
    * @example
    * ```typescript
@@ -1200,7 +1200,7 @@ export class Context {
   head(init: ContextInitializer): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method HEAD.
+   * Match requests starting with the given path and requests with the method HEAD.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -1214,7 +1214,7 @@ export class Context {
   head(what: string, init: ContextInitializer): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method HEAD.
+   * Match requests matching the given regex and requests with the method HEAD.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met
    * @example
@@ -1228,7 +1228,7 @@ export class Context {
   head(what: RegExp, init: ContextInitializer): Context;
 
   /**
-   * Search for requests with the method HEAD.
+   * Match requests with the method HEAD.
    * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
    * @param init - the action happening when the condition is met
    * @example
@@ -1248,7 +1248,7 @@ export class Context {
   head(init: ActionFunction): Context;
 
   /**
-   * Search for requests starting with the given path and requests with the method HEAD.
+   * Match requests starting with the given path and requests with the method HEAD.
    * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
    * @param what - the path that the condition should check for
    * @param init - the action happening when the condition is met
@@ -1271,7 +1271,7 @@ export class Context {
   head(what: string, init: ActionFunction): Context;
 
   /**
-   * Search for requests matching the given regex and requests with the method HEAD.
+   * Match requests matching the given regex and requests with the method HEAD.
    * This is a shorthand for {@link Context.head} and then {@link Context.action} inside.
    * @param what - the regex that the condition should check for
    * @param init - the action happening when the condition is met

--- a/packages/basic/src/context.ts
+++ b/packages/basic/src/context.ts
@@ -2,8 +2,8 @@
  * @fileOverview Context class and types / functions related to it
  * The context class is used to describe a route. Context can be nested using {@link ContextChildCondition} as children (generated using the when function).
  */
-import debug from "debug";
 import { Method, Request, Response } from "@rster/common";
+import debug from "debug";
 import {
   ConditionInfo,
   ContextCondition,
@@ -12,7 +12,6 @@ import {
   ContextConditionPath,
   ContextConditionPath2,
 } from "./condition";
-import { HttpError } from "./error";
 import { RestfulApi } from "./index";
 
 const debugRoutePath = debug("rster:router:path");
@@ -548,7 +547,7 @@ export class Context {
         toInitializer(arg1)
       );
     // post(init)
-    else if (typeof arg0 === "function")
+    if (typeof arg0 === "function")
       return this.when(new ContextConditionMethod("post"), toInitializer(arg0));
 
     throw new Error("Invalid arguments");
@@ -673,7 +672,7 @@ export class Context {
         toInitializer(arg1)
       );
     // get(init)
-    else if (typeof arg0 === "function")
+    if (typeof arg0 === "function")
       return this.when(new ContextConditionMethod("get"), toInitializer(arg0));
     throw new Error("Invalid arguments");
   }
@@ -718,22 +717,88 @@ export class Context {
    * ```
    */
   put(what: RegExp, init: ContextInitializer): Context;
+
+  /**
+   * Search for requests with the method PUT.
+   * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.put(async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.put(function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  put(init: ActionFunction): Context;
+
+  /**
+   * Search for requests starting with the given path and requests with the method PUT.
+   * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
+   * @param what - the path that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.put("/hello", async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.put("/hello", function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  put(what: string, init: ActionFunction): Context;
+
+  /**
+   * Search for requests matching the given regex and requests with the method PUT.
+   * This is a shorthand for {@link Context.put} and then {@link Context.action} inside.
+   * @param what - the regex that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.put(/\/hello/, async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.put(/\/hello/, function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  put(what: RegExp, init: ActionFunction): Context;
+
   put(
-    arg0: string | RegExp | ContextInitializer,
-    arg1?: ContextInitializer
+    arg0: string | RegExp | ContextInitializer | ActionFunction,
+    arg1?: ContextInitializer | ActionFunction
   ): this {
+    // put(what: string, init)
     if (typeof arg0 === "string" && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("put").and(new ContextConditionPath(arg0)),
-        arg1
+        toInitializer(arg1)
       );
+    // put(what: RegExp, init)
     if (arg0 instanceof RegExp && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("put").and(new ContextConditionPath2(arg0)),
-        arg1
+        toInitializer(arg1)
       );
-    else if (typeof arg0 === "function")
-      return this.when(new ContextConditionMethod("put"), arg0);
+    // put(init)
+    if (typeof arg0 === "function")
+      return this.when(new ContextConditionMethod("put"), toInitializer(arg0));
     throw new Error("Invalid arguments");
   }
 
@@ -777,24 +842,93 @@ export class Context {
    * ```
    */
   patch(what: RegExp, init: ContextInitializer): Context;
+
+  /**
+   * Search for requests with the method PATCH.
+   * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.patch(async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.patch(function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  patch(init: ActionFunction): Context;
+
+  /**
+   * Search for requests starting with the given path and requests with the method PATCH.
+   * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
+   * @param what - the path that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.patch("/hello", async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.patch("/hello", function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  patch(what: string, init: ActionFunction): Context;
+
+  /**
+   * Search for requests matching the given regex and requests with the method PATCH.
+   * This is a shorthand for {@link Context.patch} and then {@link Context.action} inside.
+   * @param what - the regex that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.patch(/\/hello/, async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.patch(/\/hello/, function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  patch(what: RegExp, init: ActionFunction): Context;
   patch(
-    arg0: string | RegExp | ContextInitializer,
-    arg1?: ContextInitializer
+    arg0: string | RegExp | ContextInitializer | ActionFunction,
+    arg1?: ContextInitializer | ActionFunction
   ): this {
+    // patch(what: string, init)
     if (typeof arg0 === "string" && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("patch").and(new ContextConditionPath(arg0)),
-        arg1
+        toInitializer(arg1)
       );
+
+    // patch(what: RegExp, init)
     if (arg0 instanceof RegExp && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("patch").and(
           new ContextConditionPath2(arg0)
         ),
-        arg1
+        toInitializer(arg1)
       );
-    else if (typeof arg0 === "function")
-      return this.when(new ContextConditionMethod("patch"), arg0);
+    // patch(init)
+    if (typeof arg0 === "function")
+      return this.when(
+        new ContextConditionMethod("patch"),
+        toInitializer(arg0)
+      );
     throw new Error("Invalid arguments");
   }
 
@@ -838,26 +972,95 @@ export class Context {
    * ```
    */
   delete(what: RegExp, init: ContextInitializer): Context;
+
+  /**
+   * Search for requests with the method DELETE.
+   * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.delete(async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.delete(function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  delete(init: ActionFunction): Context;
+
+  /**
+   * Search for requests starting with the given path and requests with the method DELETE.
+   * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
+   * @param what - the path that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.delete("/hello", async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.delete("/hello", function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  delete(what: string, init: ActionFunction): Context;
+
+  /**
+   * Search for requests matching the given regex and requests with the method DELETE.
+   * This is a shorthand for {@link Context.delete} and then {@link Context.action} inside.
+   * @param what - the regex that the condition should check for
+   * @param init - the action happening when the condition is met
+   * @example
+   * ```typescript
+   * Context.current.delete(/\/hello/, async (req, res) => {
+   *   res.status(200).json({ message: "Hello World!" }).end();
+   * });
+   *
+   * // Is the same as this:
+   * Context.current.delete(/\/hello/, function() {
+   *   this.action(async (req, res) => {
+   *     res.status(200).json({ message: "Hello World!" }).end();
+   *   });
+   * });
+   * ```
+   */
+  delete(what: RegExp, init: ActionFunction): Context;
+
   delete(
-    arg0: string | RegExp | ContextInitializer,
-    arg1?: ContextInitializer
+    arg0: string | RegExp | ContextInitializer | ActionFunction,
+    arg1?: ContextInitializer | ActionFunction
   ): this {
+    // delete(what: string, init)
     if (typeof arg0 === "string" && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("delete").and(
           new ContextConditionPath(arg0)
         ),
-        arg1
+        toInitializer(arg1)
       );
+    // delete(what: RegExp, init)
     if (arg0 instanceof RegExp && typeof arg1 === "function")
       return this.when(
         new ContextConditionMethod("delete").and(
           new ContextConditionPath2(arg0)
         ),
-        arg1
+        toInitializer(arg1)
       );
-    else if (typeof arg0 === "function")
-      return this.when(new ContextConditionMethod("delete"), arg0);
+    // delete(init)
+    if (typeof arg0 === "function")
+      return this.when(
+        new ContextConditionMethod("delete"),
+        toInitializer(arg0)
+      );
     throw new Error("Invalid arguments");
   }
 


### PR DESCRIPTION
Introduce shortcuts for actions inside of `Context#describe()`, `Context#any()`, `Context#post()`, `Context#put()`, `Context#patch()`, `Context#delete()`, `Context#options()`, `Context#head()`, `Context#get()`